### PR TITLE
Fix update setup info

### DIFF
--- a/core/Experiment.py
+++ b/core/Experiment.py
@@ -184,8 +184,8 @@ class ExperimentClass:
             for ctable in condition_tables:  # insert dependant condition tables
                 core = [field for field in self.logger.get_table_keys(schema, ctable, key_type='primary') if field != hsh]
                 fields = [field for field in self.logger.get_table_keys(schema, ctable)]
-                if not np.all([np.any(np.array(k) == list(cond.keys())) for k in fields]):
-                    if self.logger.manual_run: print('skipping ', ctable)
+                if not all(k in cond for k in fields):
+                    logging.warning("skipping table: %s, because of missing attributes: %s", ctable, [k for k in fields if k not in cond])
                     continue  # only insert complete tuples
                 if core and hasattr(cond[core[0]], '__iter__'):
                     for idx, pcond in enumerate(cond[core[0]]):

--- a/core/Experiment.py
+++ b/core/Experiment.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import time
 from dataclasses import dataclass, field
 
@@ -240,11 +241,11 @@ class ExperimentClass:
                 if perf >= self.curr_cond['stair_up']:
                     self.cur_block = self.curr_cond['next_up']
                     self.cur_block_sz = 0
-                    self.logger.update_setup_info({'difficulty': self.cur_block})
+                    self.logger.update_setup_info({'difficulty': self.cur_block, 'block': False})
                 elif perf < self.curr_cond['stair_down']:
                     self.cur_block = self.curr_cond['next_down']
                     self.cur_block_sz = 0
-                    self.logger.update_setup_info({'difficulty': self.cur_block})
+                    self.logger.update_setup_info({'difficulty': self.cur_block, 'block': False})
             if self.curr_cond['antibias']:
                 anti_bias = self._anti_bias(choice_h, self.un_choices[self.un_blocks == self.cur_block])
                 condition_idx = np.logical_and(self.choices == anti_bias, self.blocks == self.cur_block)

--- a/core/Logger.py
+++ b/core/Logger.py
@@ -779,22 +779,22 @@ class Logger:
         except socket.error:
             return False
 
-    def update_setup_info(self, info: Dict[str, Any], key: Optional[Dict[str, Any]] = None):
+    def update_setup_info(self, info: Dict[str, Any], key: Optional[Dict[str, Any]] = None, block: bool = True):
         """
-        This method updates the setup information in Control table with the provided info and key.
+        Updates the setup information in the Control table with the provided info and key.
 
-        It first fetches the existing setup information from the experiment's Control table,
-        then updates it with the provided info. If 'status' is in the provided info, it blocks
-        and validates the update operation.
+        This method fetches the existing setup information from the experiment's Control table,
+        updates it with the provided info. If 'status' is included in the info, it sets the update status and
+        logs the caller's information.
 
         Args:
-            info (dict): The information to update the setup with.
-            key (dict, optional): Additional keys to fetch the setup information with.
-            Defaults to an empty dict.
+            info (dict): The information to update the setup with. This should include any
+                         relevant fields, such as 'status' and 'notes'.
+            key (dict, optional): Additional keys to filter the setup information. If None,
+                                  defaults to an empty dictionary.
 
-        Side Effects:
-            Updates the setup_info attribute with the new setup information.
-            Updates the setup_status attribute with the new status.
+        Raises:
+            Exception: If an exception has occurred in threads running in logger.
         """
         if self.thread_exception:
             self.thread_exception = None
@@ -805,8 +805,7 @@ class Logger:
         if not public_conn.is_connected:
             set_connection()
 
-        block = True if "status" in info else False
-        if block:
+        if "status" in info:
             self.update_status.set()
             caller = inspect.stack()[1]
             caller_info = (f"Function called by {caller.function} "


### PR DESCRIPTION
add default keyword argument block=True in update_setup_info and not only when status is in info

This is done because PyWelcome in order to update the task_idx with update_setup_info and we want to make sure it is done before open the window for starting the experiment.

Also use logging for the skipping tables and show which keys are missing from the table and is being skipped